### PR TITLE
Detailpagina

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -201,6 +201,125 @@ nav {
 }
 
 /* =================== STEKJES BIEB =================== */
+/* =================== DETAIL PAGINA  =================== */
+
+.main-stekje { 
+  font-family: var(--font-family-text);
+  background-color: var(--background-color);
+}
+
+.terugknop{
+  text-decoration: none;
+  font-family: poppins, sans-serif;
+  font-weight: var(--font-weight-bold);
+  background-color: var(--main-color-beige);
+  color: var(--main-color-brown);
+  padding: 10px 20px;
+  border: solid 2px var(--main-color-brown);
+  border-radius: 30px;
+  max-width: 100px;
+}
+
+.terugknop:hover {
+  background-color: var(--main-color-brown);
+  color: var(--main-color-beige);
+  transition: background-color 0.3s ease;
+}
+.stekje-info {
+  background-color: var(--main-color-beige);
+  display: flex;
+  flex-direction: column;
+  border-radius: 30px;
+  padding: 30px;
+  gap: 40px;
+  max-width: 95%;
+  margin: 30px auto;
+}
+
+.stekje-description {
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  padding: 10px;
+  color: var(--main-color-brown);
+}
+
+.stekje-description h2 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: var(--text-color-brown);
+}
+
+.stekje-description img {
+  width: 70%;
+  max-width: 70%;
+  border-radius: 15px;
+  margin-top: 1.5rem;
+  box-shadow: 40px 8px 15px #F4CA8B;
+  transition: transform 0.3s ease;
+  align-items: center;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.stekje-description img:hover {
+  transform: scale(1.05);
+}
+
+.stekje-kenmerken {
+  display: flex;
+  flex-direction: column;
+  background-color: #F4CA8B;
+  padding: 15px;
+  border-radius: 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.stekje-details {
+  background: #F4CA8B;
+  padding: 15px;
+  margin-bottom: 10px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.stekje-details:hover {
+  background: var(--card-color-orange);
+}
+
+.stekje-summary {
+  font-weight: bold;
+  color: var(--main-color-brown);
+  font-size: 16px;
+  list-style: none;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.stekje-details p {
+  color: var(--main-color-brown);
+  font-size: 14px;
+  margin: 10px 0 0;
+}
+
+.stekje-details h3 {
+  font-size: 18px;
+}
+
+.stekje-summary::after {
+  content: " +";
+  font-size: 18px;
+  color: var(--main-color-brown);
+}
+
+.stekje-details[open] .stekje-summary::after {
+  content: " -";
+}
+
 /* =================== BIEB BLOK =================== */
 .bieb-blok {
   padding: clamp(1.5rem, 2vw, 3rem) 1rem;

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -320,6 +320,50 @@ nav {
   content: " -";
 }
 
+/* DETAILPAGINA DESKTOP*/
+
+@media (min-width: 768px) {
+  .stekje-info {
+    flex-direction: row;
+    padding: 60px;
+    gap: 100px;
+    border-radius: 50px;
+    max-width: 90%;
+  }
+
+  .terugknop {
+    max-height: 50px;
+  }
+
+  .stekje-description {
+    max-width: 700px;
+    padding: 20px;
+    margin: 0 auto;
+    text-align: left;
+  }
+
+  .stekje-description img {
+    max-width: 250px;
+    margin-top: 5rem;
+    border-radius: 30px;
+    box-shadow: 150px 20px 30px #F4CA8B;
+    margin-left: 0;
+
+  }
+
+  .stekje-kenmerken {
+    width: 1500px;
+  }
+
+  .stekje-details {
+    padding: 20px;
+  }
+
+  .stekje-details h3 {
+    font-size: 20px;
+  }
+}
+
 /* =================== BIEB BLOK =================== */
 .bieb-blok {
   padding: clamp(1.5rem, 2vw, 3rem) 1rem;

--- a/server.js
+++ b/server.js
@@ -46,6 +46,16 @@ app.get('/stekjes', async function (request, response) {
     response.status(500).send('Er ging iets mis bij het ophalen van de stekjes 😢')
   }
 })
+// dynamische route detalpagina 
+app.get('/stekjes/:id', async function (request, response) {
+  const stekjeId = request.params.id;
+  const stekjeResponse = await fetch(`https://fdnd-agency.directus.app/items/bib_stekjes/${stekjeId}`);
+  const stekjeData = await stekjeResponse.json();
+ 
+ 
+  response.render('detail.liquid', { stekje: stekjeData.data });
+ });
+   
 
 // Zaden
 app.get('/zaden', async function (request, response) {

--- a/views/detail.liquid
+++ b/views/detail.liquid
@@ -1,0 +1,65 @@
+{% render 'partials/head.liquid' %}
+
+<main class="main-stekje">
+<section class="stekje-info">
+  <a href="/stekjes" class="terugknop">terug</a>
+  <section class="stekje-description">
+    <h2>{{ stekje.naam }}</h2>
+    <p>{{ stekje.beschrijving }}</p>
+    <img src="https://fdnd-agency.directus.app/assets/{{ stekje.foto }}" alt="{{ stekje.naam }}">
+  </section>
+  <section class="stekje-kenmerken">
+
+    {% if stekje.land_van_herkomst %}
+      <details class="stekje-details">
+        <summary class="stekje-summary">LANDHERKOMST</summary>
+        <p>{{ stekje.land_van_herkomst }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.voeding %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">VOEDING</summary>
+        <p>{{ stekje.voeding }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.temperatuur %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">TEMPRATUUR</summary>
+        <p>{{ stekje.temperatuur }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.giftig %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">GIFTIG</summary>
+        <p>{{ stekje.giftig }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.verpotten %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">VERPOTTEN</summary>
+        <p>{{ stekje.verpotten }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.watergeven %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">WATERGEVEN</summary>
+        <p>{{ stekje.watergeven }}</p>
+      </details>
+    {% endif %}
+  
+    {% if stekje.zonlicht %}
+        <details class="stekje-details">
+        <summary class="stekje-summary">ZONLICHT</summary>
+        <p>{{ stekje.zonlicht }}</p>
+      </details>
+    {% endif %}
+  </section>
+
+</section>
+</main>
+{% render 'partials/foot.liquid' %}


### PR DESCRIPTION
### Dynamische detail pagina stekjes 

_Ik heb gewerkt aan de detailpagina. dit is een dynamische pagina waarbij je komt als je op een van de stekjes drukt op de stekjes pagina. ik heb een terugknop toegevoegd die je terug leidt van de detail pagina naar de stekjes pagina. De detailpagina heeft een kenmerk functie deze kenmerken worden dynamische geladen vanuit de database. alleen de kenmerken die bij dit stekje horen komen tervoorschijn als openklap menu._

Dit is het figma design
 
<img width="517" alt="Scherm­afbeelding 2025-05-26 om 10 52 50" src="https://github.com/user-attachments/assets/b262fa5c-4cbf-4fe2-9100-947d8a6028ee" />


https://github.com/user-attachments/assets/91f42562-ef95-408f-959d-3473f206dd0b

### wat heb ik gedaan
- dynamische route aangemaakt in server.js naar detailpagina
- een forloop gemaakt in liquid voor de kenmerken zodat op de juiste manier getoond worden en bij het juiste stekje.
- kenmerken openklap menu functie gestyled in  css 
- met css de pagina gestyled
- zoom animatie toegevoegd img 
- responsive gemaakt
- terugknop naar stekjespagina 

### waar wil ik feedback op 
- kan het gebruikt worden op meerder apparaten ( reponsice)
- laad de dynamische route 
- toont deze de juiste stekjes detailpagina bij het stekje
- hoe komt het visueel over komet het overheen met de pagina 
- doet de terugknop het 

@Keremttc @saschavanvliet zouden jullie hier naar willen kijken? 



