### PR TITLE
Geveltuin debug header

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -125,6 +125,7 @@ h1 {
 .nav-links details ul {
   padding-left: 1.5rem; 
   list-style: none;
+  z-index: 1000;
 }
 
 .nav-links details ul li a {
@@ -265,7 +266,7 @@ h1 {
   }
 }
 
-main { 
+.main-stekjes { 
   overflow: hidden;
   background-color: var(--main-color-brown);
 }
@@ -452,8 +453,6 @@ margin-top: 300px;
   overflow-y: visible;
   padding: 1rem;
 }
-
-
  
 .stekje img {
   width: 100%;
@@ -525,10 +524,7 @@ margin-top: 300px;
   .stekje-kenmerken {
     min-width: 300px;
     width: 1500px;
-
-
   }
-
 
   .uitleg-stekjes {
     font-size: 16px;
@@ -1317,7 +1313,6 @@ input::placeholder {
     font-size: 1.5rem;
   }
 }
-
 
 /* Geveltuin */
 

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -1188,7 +1188,6 @@ input::placeholder {
   }
 }
 
-
 .geveltuin {
   box-sizing: border-box;
   border: 1px solid var(--main-color-green);
@@ -1342,7 +1341,15 @@ input::placeholder {
   justify-content: center;
   text-align: center;
   padding: 2rem;
-}
+@media (min-width: 768px) {
+  font-size: 4rem;
+}}
+
+@media (min-width: 768px) {
+.main-geveltuin h1 {
+  font-size: 4rem;
+}}
+
 
 .main-geveltuin p {
   margin-left: 2em;
@@ -1357,7 +1364,6 @@ input::placeholder {
   color: var(--card-color-green);
   text-align: center;
   transform: translateY(-15rem);
-
   max-width: 90%;
   margin: 0 auto;
   position: relative;

--- a/views/stekjes.liquid
+++ b/views/stekjes.liquid
@@ -18,7 +18,7 @@
   </p>
 </article>
 
-<main>
+<main class="main-stekjes">
   <section class="stekjeskast">
     <h2>Stekjes <span>kast</span></h2>
     <p>“Onze Stekjeskast is met liefde gemaakt door kinderen. Hieronder vind


### PR DESCRIPTION
<img width="1455" alt="image" src="https://github.com/user-attachments/assets/03b7d7de-280f-4c9e-8d38-abcb976bdb42" />

Hoi @Nayome, 

Ik heb de header als component nu gefixt. Na het mergen was het natuurlijk niet goed gegaan, waardoor de div achter de image kwam te staan. Zou jij even kunnen kijken of je dit kan mergen zodat je daarna de animatie hierin kan toevoegen?